### PR TITLE
updated lapack install command for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone https://github.com/magland/mountainlab.git
 
 **Installation of Lapack:**
 ```bash
-Ubuntu/Debian: sudo apt-get install liblapack liblapacke liblapack-dev liblapacke-dev
+Ubuntu/Debian: sudo apt-get install libfftw3-dev liblapacke liblapack-dev liblapacke-dev
 CentOS/Red Hat: sudo yum install lapack-devel.x86_64
 ```
 


### PR DESCRIPTION
`sudo apt-get install liblapack`
> E: Unable to locate package liblapack

On my Ubuntu 14.04 I needed to install `libfftw3-dev`, otherwise the "fftw3.h" header was not found.

@magland since this is my first contribution, I'm not sure if "fork / pull request / merge" is the preferred workflow here. Is this OK or would you prefer a patch ?