### PR TITLE
removed some duplicated code from mdaio.cpp

### DIFF
--- a/mountainsort/src/mda/mdaio.cpp
+++ b/mountainsort/src/mda/mdaio.cpp
@@ -1,5 +1,6 @@
 #include "mdaio.h"
 #include "usagetracking.h"
+#include <vector>
 
 //can be replaced by std::is_same when C++11 is enabled
 template<class T, class U> struct is_same { enum { value = 0 }; };
@@ -256,12 +257,9 @@ long mdaWriteData_impl(DataType* data, const long size, FILE* outputFile) {
 	if (is_same<DataType, TargetType>::value) {
 		return fwrite(data, sizeof(DataType), size, outputFile);
 	} else {
-		TargetType *tmp=(TargetType *)malloc(sizeof(TargetType) * size);
-		for (long i=0; i<size; i++)
-			tmp[i]=(TargetType)data[i];
-		const long result = fwrite(tmp, sizeof(TargetType), size, outputFile);
-		free(tmp);
-		return result;
+		std::vector<TargetType> tmp(size);
+		std::copy(data, data + size, tmp.begin());
+		return fwrite(&tmp[0], sizeof(TargetType), size, outputFile);
 	}
 }
 


### PR DESCRIPTION
Replaced `MDA_WRITE_MACRO` with template methods to remove code duplication.
Same can be done with `MDA_READ_MACRO` (another pull request).

Further cleanup can be done by introducing type traits class for `MDAIO_HEADER`, so the code
```c++
...
else if (header->data_type==MDAIO_TYPE_INT16) {
	return mdaWriteData_impl<int16_t>(data, size, outputFile);
 }
else if (header->data_type==MDAIO_TYPE_INT32) {
	return mdaWriteData_impl<int32_t>(data, size, outputFile);
 }
...
```
could be replaced by something like
```c++
return mdaWriteData_impl<HeaderTypeTraits<header->data_type>::type>(data, size, outputFile);
```
@magland 