### PR TITLE
fix for preview size in export image dialog

### DIFF
--- a/mountainview/src/imagesavedialog.cpp
+++ b/mountainview/src/imagesavedialog.cpp
@@ -8,6 +8,8 @@
 #include <QFileDialog>
 #include <QImageWriter>
 #include <QMessageBox>
+#include <QDesktopWidget>
+#include <QApplication>
 
 class ImageSaveDialogPrivate {
 public:
@@ -74,11 +76,25 @@ void ImageSaveDialog::presentImage(const QImage& img)
     dlg.exec();
 }
 
+static QPixmap fit_display(const QImage& img) {
+    static QRect screenRect;
+    static int margin = 20;
+    QPixmap result = QPixmap::fromImage(img);
+    if (screenRect.isNull())
+        screenRect = QApplication::desktop()->availableGeometry();
+    if (result.width() > screenRect.width())
+        result = result.scaledToWidth(screenRect.width() - margin, Qt::SmoothTransformation);
+    if (result.height() > screenRect.height())
+        result = result.scaledToHeight(screenRect.height() - margin, Qt::SmoothTransformation);
+    return result;
+}
+
 void ImageSaveDialog::setImage(const QImage& img)
 {
     d->m_image = img;
-    d->m_label->setPixmap(QPixmap::fromImage(img));
-    d->m_label->resize(img.width(), img.height());
+    const QPixmap toDisplay = fit_display(img);
+    d->m_label->setPixmap(toDisplay);
+    d->m_label->resize(toDisplay.width(), toDisplay.height());
 }
 
 void ImageSaveDialog::slot_save()


### PR DESCRIPTION
Preview image displayed in "export image" dialog sometimes didn't fit the desktop size.

Before:
![before](https://cloud.githubusercontent.com/assets/13024128/14769851/88f12c8c-0a62-11e6-9a7e-2b82abb23843.png)

After the fix:
![after](https://cloud.githubusercontent.com/assets/13024128/14769855/9168a52a-0a62-11e6-8628-7b226c9291a1.png)

Original image saved to disk is not affected.
@magland 