### PR TITLE
sse2 for few functions in bandpass filter

### DIFF
--- a/common/mda/mda.h
+++ b/common/mda/mda.h
@@ -11,6 +11,8 @@
 #include <QDebug>
 #endif
 
+extern void* allocate(const size_t nbytes);
+
 class MdaPrivate;
 /** \class Mda - a multi-dimensional array corresponding to the .mda file format
  * @brief The Mda class

--- a/mountainsort/src/mountainsort.pro
+++ b/mountainsort/src/mountainsort.pro
@@ -133,6 +133,7 @@ SOURCES += utils/get_command_line_params.cpp \
     processors/geom2adj_processor.cpp
 
 DEFINES += USE_REMOTE_MDA
+DEFINES += USE_SSE2
 INCLUDEPATH += ../../common/mda
 DEPENDPATH += ../../common/mda
 VPATH += ../../common/mda


### PR DESCRIPTION
- do not reallocate MDA data when source has the same size in `copy_from`
- removed temporary array for grid values in `define_kernel` in `bandpass_filter`
- vectorized some multiplication loops in `bandpass_filter` with sse2
- MDA allocates aligned memory when compiling with SSE

Verified results by comparing the output files from `bandpass_filter` before and after this update (`diff` reports no change in them). Unit tests for MDA passed too.

Example time measurements for the bandpass step:
```
before:
228,84 sec
218,969 sec
231,087 sec
230,892 sec
203,238 sec

after:
194,342 sec
201,884 sec
194,582 sec
205,13 sec
195,753 sec
```

Not much of a speed up, but this seems to be dominated by fft anyway.

@magland I worked on this code as I could not run any steps after the `whiten` processor.... I will try again tomorrow by doing a fresh install.