### PR TITLE
Modify the way mountainbrowser forwards all stdout traffic from its child processes

### DIFF
--- a/mountainbrowser/src/mbcontroller.cpp
+++ b/mountainbrowser/src/mbcontroller.cpp
@@ -10,6 +10,7 @@
 #include <QProcess>
 #include "msmisc.h"
 #include "mlutils.h"
+#include <stdio.h>
 
 #include <QJsonDocument>
 #include <QDebug>
@@ -105,6 +106,9 @@ void MBController::slot_ready_read()
         qWarning() << "Unexpected problem in slot_ready_read";
         return;
     }
-    QByteArray str = P->readAll();
-    printf("%s", str.data());
+    while(P->canReadLine()) {
+        QByteArray str = P->readLine();
+        printf("%s", str.constData());
+        fflush(stdout);
+    }
 }


### PR DESCRIPTION
This change makes sure entire lines are printed.