### PR TITLE
Fix Compilation Error

### DIFF
--- a/packages/mountainsort2/src/p_isolation_metrics.cpp
+++ b/packages/mountainsort2/src/p_isolation_metrics.cpp
@@ -619,7 +619,7 @@ QJsonObject get_pair_metrics(const DiskReadMda32& X, const QVector<double>& time
 }
 bool is_bursting_parent_candidate(const Mda32& template0, const Mda32& template0_parent, P_isolation_metrics_opts opts)
 {
-    double maxabs = 0, maxabs_parent = 0;
+    float maxabs = 0, maxabs_parent = 0;
     for (bigint i = 0; i < template0.totalSize(); i++) {
         maxabs = qMax(fabs(template0.value(i)), maxabs);
         maxabs_parent = qMax(fabs(template0_parent.value(i)), maxabs_parent);


### PR DESCRIPTION
Currently I get the error below compiling on fedora 25 (qt version 5.8). Changing the maxabs value from a double to a float fixes the issue but I'm not sure maybe the extra precision is required here?

```
g++ -c -pipe -fopenmp -O2 -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -I../../../mlcommon/include -I../../../mlcommon/include/cachemanager -I../../../mlcommon/includ
e/componentmanager -I../../../mlcommon/include/mda -I../../../mountainsort/src/isosplit5 -I../../../mountainsort/src/utils -I/home/data/Qt/5.8/gcc_64/include -I/home/data/Qt/5.8/gcc_64/include/QtNetwork -I/home/
data/Qt/5.8/gcc_64/include/QtCore -I../build -I/home/data/Qt/5.8/gcc_64/mkspecs/linux-g++ -o ../build/p_isolation_metrics.o p_isolation_metrics.cpp
p_isolation_metrics.cpp: In function ‘bool P_isolation_metrics::is_bursting_parent_candidate(const Mda32&, const Mda32&, P_isolation_metrics_opts)’:
p_isolation_metrics.cpp:624:55: error: no matching function for call to ‘qMax(float, double&)’
         maxabs = qMax(fabs(template0.value(i)), maxabs);
                                                       ^
In file included from /home/data/Qt/5.8/gcc_64/include/QtCore/qalgorithms.h:43:0,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/qlist.h:43,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/qstringlist.h:41,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/QStringList:1,
                 from p_isolation_metrics.h:4,
                 from p_isolation_metrics.cpp:1:
/home/data/Qt/5.8/gcc_64/include/QtCore/qglobal.h:537:34: note: candidate: template<class T> constexpr const T& qMax(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMax(const T &a, const T &b) { return (a < b) ? b : a; }
                                  ^~~~
/home/data/Qt/5.8/gcc_64/include/QtCore/qglobal.h:537:34: note:   template argument deduction/substitution failed:
p_isolation_metrics.cpp:624:55: note:   deduced conflicting types for parameter ‘const T’ (‘float’ and ‘double’)
         maxabs = qMax(fabs(template0.value(i)), maxabs);
p_isolation_metrics.cpp:625:76: error: no matching function for call to ‘qMax(float, double&)’
         maxabs_parent = qMax(fabs(template0_parent.value(i)), maxabs_parent);
                                                                            ^
In file included from /home/data/Qt/5.8/gcc_64/include/QtCore/qalgorithms.h:43:0,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/qlist.h:43,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/qstringlist.h:41,
                 from /home/data/Qt/5.8/gcc_64/include/QtCore/QStringList:1,
                 from p_isolation_metrics.h:4,
                 from p_isolation_metrics.cpp:1:
/home/data/Qt/5.8/gcc_64/include/QtCore/qglobal.h:537:34: note: candidate: template<class T> constexpr const T& qMax(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMax(const T &a, const T &b) { return (a < b) ? b : a; }
                                  ^~~~
/home/data/Qt/5.8/gcc_64/include/QtCore/qglobal.h:537:34: note:   template argument deduction/substitution failed:
p_isolation_metrics.cpp:625:76: note:   deduced conflicting types for parameter ‘const T’ (‘float’ and ‘double’)
         maxabs_parent = qMax(fabs(template0_parent.value(i)), maxabs_parent);
                                                                            ^
Makefile.mountainsort2:2674: recipe for target '../build/p_isolation_metrics.o' failed
make[1]: *** [../build/p_isolation_metrics.o] Error 1
make[1]: Leaving directory '/ddLab/code/mountainlab/packages/mountainsort2/src'
Makefile:526: recipe for target 'sub-packages-mountainsort2-src-mountainsort2-pro-make_first-ordered' failed
make: *** [sub-packages-mountainsort2-src-mountainsort2-pro-make_first-ordered] Error 2
Problem in compilation.
```