### PR TITLE
Add checkout step to install instructions for stable branches

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -30,6 +30,7 @@ First time:
 ```bash
 git clone https://github.com/magland/mountainlab.git
 cd mountainlab
+git checkout ms3 # switch to stable mountainsort 3 branch
 ./compile_components.sh
 ```
 


### PR DESCRIPTION
Update the install instructions for the recommended stable (non-master) branches, to include the step of switching to that branch. Will fix this for mountainsort 2 (2017_06 branch) and mountainsort 3 (ms3)